### PR TITLE
Improve https retry

### DIFF
--- a/src/pkg/egress/syslog/https_batch.go
+++ b/src/pkg/egress/syslog/https_batch.go
@@ -114,9 +114,9 @@ func NewHTTPSBatchWriter(
 		retryer: Retryer{
 			binding: binding,
 		},
-		batchSize:    256 * 1024,        // Default value
-		sendInterval: 1 * time.Second,   // Default value
-		msgChan:      make(chan []byte), // Buffered channel for messages
+		batchSize:    256 * 1024,              // Default value
+		sendInterval: 1 * time.Second,         // Default value
+		msgChan:      make(chan []byte, 1024), // Buffered channel for messages
 		quit:         make(chan struct{}),
 	}
 


### PR DESCRIPTION
# Description

- Add round-robin worker pool with isolated retries for HTTPSBatchWriter
- Buffer msgChan to prevent blocking during high-throughput writes

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
